### PR TITLE
⬆ Update dependencies, implement new Retrofit timeout() method

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,11 +28,16 @@ android {
         exclude 'AndroidManifest.xml'
         exclude 'META-INF/atomicfu.kotlin_module'
     }
+
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 ext {
     restMockVersion = '0.3.1'
-    stethoVersion = '1.5.0'
+    stethoVersion = '1.5.1'
 }
 
 dependencies {
@@ -50,8 +55,8 @@ dependencies {
 
     implementation "com.github.andrzejchm.RESTMock:android:$restMockVersion"
     implementation "com.facebook.stetho:stetho:$stethoVersion"
-    
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.0-alpha"
+
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
     testImplementation "junit:junit:$junitVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.3"
+        classpath "com.android.tools.build:gradle:4.0.0"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -33,10 +33,10 @@ ext.libProperties.load(file("${rootDir}/lib.properties").newReader())
 
 ext {
     appcompatVersion = '1.1.0'
-    retrofitVersion = '2.6.1'
-    coroutinesVersion = '1.3.2'
-    junitVersion = '4.12'
-    mockitoVersion = '1.10.19'
+    retrofitVersion = '2.8.1'
+    coroutinesVersion = '1.3.5'
+    junitVersion = '4.13'
+    mockitoVersion = '3.3.3'
     annotationVersion = '1.0.0'
     espressoVersion = '3.1.0-alpha3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext.libProperties.load(file("${rootDir}/lib.properties").newReader())
 ext {
     appcompatVersion = '1.1.0'
     retrofitVersion = '2.8.1'
-    coroutinesVersion = '1.3.5'
+    coroutinesVersion = '1.3.7'
     junitVersion = '4.13'
     mockitoVersion = '3.3.3'
     annotationVersion = '1.0.0'

--- a/coroutineadapter/src/main/java/cz/ackee/retrofitadapter/interceptor/CallDelegate.kt
+++ b/coroutineadapter/src/main/java/cz/ackee/retrofitadapter/interceptor/CallDelegate.kt
@@ -5,11 +5,12 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-interface CallableDelegate<OUT>: Call<OUT>
+interface CallableDelegate<OUT> : Call<OUT>
 
 abstract class CallDelegate<IN, OUT>(
     protected val proxy: Call<IN>
 ) : CallableDelegate<OUT> {
+
     override fun execute(): Response<OUT> = throw NotImplementedError()
     override fun enqueue(callback: Callback<OUT>) = enqueueImpl(callback)
     override fun clone(): Call<OUT> = cloneImpl()
@@ -18,6 +19,7 @@ abstract class CallDelegate<IN, OUT>(
     override fun request(): Request = proxy.request()
     override fun isExecuted() = proxy.isExecuted
     override fun isCanceled() = proxy.isCanceled
+    override fun timeout() = proxy.timeout()
 
     abstract fun enqueueImpl(callback: Callback<OUT>)
     abstract fun cloneImpl(): Call<OUT>

--- a/coroutineoauth/src/main/java/cz/ackee/ackroutine/CoroutineCall.kt
+++ b/coroutineoauth/src/main/java/cz/ackee/ackroutine/CoroutineCall.kt
@@ -6,15 +6,22 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import okhttp3.Request
+import okio.Timeout
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
 /**
  * [CallableDelegate] which invokes suspending function.
  */
 internal class CoroutineCall<OUT>(val operation: suspend () -> OUT) : CallableDelegate<OUT>, CoroutineScope {
+
+    companion object {
+
+        private const val TIMEOUT_S: Long = 15
+    }
 
     private val job = Job()
 
@@ -56,5 +63,9 @@ internal class CoroutineCall<OUT>(val operation: suspend () -> OUT) : CallableDe
 
     override fun request(): Request {
         throw NotImplementedError()
+    }
+
+    override fun timeout(): Timeout {
+        return Timeout().timeout(TIMEOUT_S, TimeUnit.SECONDS)
     }
 }

--- a/coroutineoauth/src/test/java/cz/ackee/ackroutine/OAuthManagerTest.kt
+++ b/coroutineoauth/src/test/java/cz/ackee/ackroutine/OAuthManagerTest.kt
@@ -4,10 +4,13 @@ import cz.ackee.ackroutine.core.DefaultOAuthCredentials
 import cz.ackee.ackroutine.core.OAuthCredentials
 import cz.ackee.ackroutine.core.OAuthStore
 import cz.ackee.retrofitadapter.interceptor.CallableDelegate
-import junit.framework.TestCase.*
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import okhttp3.MediaType
 import okhttp3.Request
 import okhttp3.ResponseBody
+import okio.Timeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -42,12 +45,14 @@ class OAuthManagerTest {
         override fun enqueue(callback: Callback<String>) {
             callback.onResponse(this, Response.success(successResult))
         }
+
         override fun isExecuted(): Boolean = false
         override fun clone(): Call<String> = this
         override fun isCanceled(): Boolean = false
         override fun cancel() {}
         override fun execute(): Response<String> = throw NotImplementedError()
         override fun request(): Request = throw NotImplementedError()
+        override fun timeout(): Timeout = Timeout.NONE
     }
 
     private val failureCall = object : CallableDelegate<String> {
@@ -59,15 +64,15 @@ class OAuthManagerTest {
 
             callback.onFailure(this, HttpException(response))
         }
+
         override fun isExecuted(): Boolean = false
         override fun clone(): Call<String> = this
         override fun isCanceled(): Boolean = false
         override fun cancel() {}
         override fun execute(): Response<String> = throw NotImplementedError()
         override fun request(): Request = throw NotImplementedError()
+        override fun timeout(): Timeout = Timeout.NONE
     }
-
-
 
     private var firstRun = true
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 05 16:01:47 CET 2019
+#Thu Jul 02 10:59:09 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/lib.properties
+++ b/lib.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.0.1
+VERSION_NAME=1.0.2
 VERSION_CODE=1
 GROUP=cz.ackee.ackroutine
 BINTRAY_REPO=ackroutine-adapter


### PR DESCRIPTION
Update all dependencies and implement new `timeout()` method introduced in Retrofit update.